### PR TITLE
提供基础的前端项目工程化配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ build/
 dist/
 main.js
 main.js.map
+
+# 不上传pnpm的包锁文件
+pnpm-lock.yaml

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,13 @@
+# 默认 淘宝镜像
+registry=https://registry.npmmirror.com/
+
+# 指定特定包的镜像源 确保安装时能安装到最新的包
+@ruan-cat:registry=https://registry.npmjs.org/
+
+# 关闭验证 确保安装electron时不会出现ssl验证错误
+strict-ssl=false
+
+# 手动指定依赖包的下载镜像 确保下载成功
+# https://blog.csdn.net/weixin_46525113/article/details/132299107
+electron_mirror=https://cdn.npmmirror.com/binaries/electron/
+electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,2 @@
+const config = require("@ruan-cat/commitlint-config").default;
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -15,10 +15,18 @@
     "type": "git",
     "url": "https://github.com/yami-pro/yami-rpg-editor.git"
   },
-  "dependencies": {},
+  "packageManager": "pnpm@9.15.4",
   "devDependencies": {
+    "@ruan-cat/commitlint-config": "^0.1.4",
+    "commitizen": "^4.3.1",
+    "cz-git": "^1.11.0",
     "electron": "^18.3.15",
     "electron-builder": "^23.6.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-git"
+    }
   },
   "build": {
     "appId": "com.yami.rpgeditor",


### PR DESCRIPTION
提供 packageManager .npmrc commitlint.config.cjs 配置，用于安装依赖，控制提交格式等。